### PR TITLE
feat: add camera capture page

### DIFF
--- a/src/appRoutes.js
+++ b/src/appRoutes.js
@@ -4,6 +4,7 @@ import {
   CustomerPage,
   CustomerListPage,
   Dashboard,
+  CameraPage,
 } from "pages";
 
 export const appRoutes = {
@@ -38,6 +39,12 @@ export const appRoutes = {
     name: "Dashboard",
     path: "",
     Component: Dashboard,
+    isLocked: true,
+  },
+  camera: {
+    name: "Câmera",
+    path: "camera",
+    Component: CameraPage,
     isLocked: true,
   },
 };

--- a/src/components/Menu/BottomMenu.js
+++ b/src/components/Menu/BottomMenu.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import List from "@heroicons/react/solid/ViewListIcon";
 import Dashboard from "@heroicons/react/solid/ChartBarIcon";
+import Camera from "@heroicons/react/solid/CameraIcon";
 import {
   Button,
   BUTTON_COMPONENT,
@@ -35,6 +36,17 @@ function BottomMenu() {
         <div className="flex flex-col justify-center items-center">
           <List height={20} width={20} />
           <Text size={TEXT_SIZES.VERY_SMALL}>Ordens de Serviço</Text>
+        </div>
+      </Button>
+      <Button
+        as={BUTTON_COMPONENT.LINK}
+        size={BUTTON_SIZES.SMALL}
+        variant={BUTTON_VARIANTS.GHOST}
+        href={"/camera"}
+      >
+        <div className="flex flex-col justify-center items-center">
+          <Camera height={20} width={20} />
+          <Text size={TEXT_SIZES.VERY_SMALL}>Câmera</Text>
         </div>
       </Button>
     </div>

--- a/src/pages/CameraPage/CameraPage.js
+++ b/src/pages/CameraPage/CameraPage.js
@@ -1,0 +1,94 @@
+import React, { useRef, useEffect, useCallback } from "react";
+import useSWR from "swr";
+import { useHistory } from "react-router-dom";
+
+import { PageTitle } from "components";
+import { Card, Button, BUTTON_VARIANTS, ScreenLoader } from "ui-fragments";
+import { engineAPI } from "utils";
+import { useNotification } from "hooks";
+
+const getCameraStream = async () => {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new Error("navigator.mediaDevices.getUserMedia não suportado");
+  }
+  return navigator.mediaDevices.getUserMedia({ video: true });
+};
+
+const CameraPage = () => {
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+  const history = useHistory();
+  const { data: stream, error } = useSWR("cameraStream", getCameraStream);
+
+  useEffect(() => {
+    if (stream && videoRef.current) {
+      videoRef.current.srcObject = stream;
+    }
+    return () => {
+      if (stream) {
+        stream.getTracks().forEach(track => track.stop());
+      }
+    };
+  }, [stream]);
+
+  const { showSuccessNotification, showErrorNotification } = useNotification();
+
+  const handleTakePhoto = useCallback(async () => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) {
+      return;
+    }
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const context = canvas.getContext("2d");
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    try {
+      const dataUrl = canvas.toDataURL("image/jpeg");
+      const base64Image = dataUrl.split(",")[1];
+      const { serviceOrder } = await engineAPI.service_order_images.post({
+        data: { image: base64Image },
+      });
+      showSuccessNotification({
+        id: "photoTaken",
+        title: "Foto enviada!",
+      });
+      if (serviceOrder?.id) {
+        history.push(`/services/${serviceOrder.id}`);
+      }
+    } catch (err) {
+      showErrorNotification({
+        id: "photoTakenError",
+        title: "Não foi possível enviar a foto",
+      });
+    }
+  }, [history, showErrorNotification, showSuccessNotification]);
+
+  if (!stream && !error) {
+    return <ScreenLoader isLoading={true} />;
+  }
+
+  return (
+    <Card className="flex flex-col gap-4">
+      <PageTitle title="Câmera" description="Tire uma foto da lista de peças" />
+      {error && (
+        <p className="text-error-0">
+          Não foi possível acessar a câmera do dispositivo.
+        </p>
+      )}
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        className="w-full rounded-md"
+      />
+      <canvas ref={canvasRef} className="w-full rounded-md" />
+      <Button variant={BUTTON_VARIANTS.PRIMARY} onClick={handleTakePhoto} fw>
+        Tirar Foto
+      </Button>
+    </Card>
+  );
+};
+
+export default CameraPage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,3 +5,4 @@ export { default as Dashboard } from "./Dashboard/Dashboard";
 export { default as CustomerListPage } from "./CustomerListPage/CustomerListPage";
 export { default as HomePage } from "./HomePage/HomePage";
 export { default as LoginPage } from "./LoginPage/LoginPage";
+export { default as CameraPage } from "./CameraPage/CameraPage";

--- a/src/utils/engineAPI/APIRoutes.js
+++ b/src/utils/engineAPI/APIRoutes.js
@@ -23,6 +23,10 @@ const APIRoutes = {
     url: "/service_orders_pdf",
     isLocked: true,
   },
+  service_order_images: {
+    url: "/service_order_images",
+    isLocked: true,
+  },
   reports: {
     url: "/service_orders/reports",
     isLocked: true,


### PR DESCRIPTION
## Summary
- add route and menu option for new camera page
- implement camera page using user media API and SWR
- post captured photo to `service_order_images` as base64
- redirect to service order page after successful photo upload

## Testing
- `npx eslint src/pages/CameraPage/CameraPage.js`
- `CI=true npm test`
- `npm run lint` *(fails: 'process' is not defined in serviceWorker.js)*

------
https://chatgpt.com/codex/tasks/task_e_689e3e99c1c8832ca465fb2a6ce51505